### PR TITLE
Update README.md headers settable field casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ If `parent` is set to `false`, it wil be uploaded to `gs://bucket-name/folder2/f
     and custom metadata with key `custom-field` and value `custom-value` will be
     added to it.
 
-    Settable fields are: `Cache-Control`, `Content-Disposition`,
-    `Content-Encoding`, `Content-Language`, `Content-Type`, `Custom-Time`. See
+    Settable fields are: `cache-control`, `content-disposition`,
+    `content-encoding`, `content-language`, `content-type`, `custom-time`. See
     [the
     document](https://cloud.google.com/storage/docs/gsutil/addlhelp/WorkingWithObjectMetadata#settable-fields;-field-values)
     for details.


### PR DESCRIPTION
It is a bit of a gotcha that the `headers` settable fields are the lowercase counterparts to their Header. The docs incorrectly mention the case sensitive varitions, which when followed causes an error:


```
 - uses: google-github-actions/upload-cloud-storage@v1
       with:
          path: /foo
          destination: bucket
          headers: |-
            Cache-Control: public, max-age=31536000, no-transform, immutable

google-github-actions/upload-cloud-storage failed with:
invalid header key "Cache-Control" - custom header keys must be prefixed with "x-goog-meta-"
```

For future users and clarity, I think it is best to update the documentation to use the fully lowercase versions.